### PR TITLE
fix: align dashboard tabs with dark tactical theme

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -38,7 +38,7 @@ export function TabsList({
   return (
     <div
       className={cn(
-        "inline-flex h-10 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+        "inline-flex h-10 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900/50 p-1 text-zinc-500",
         className
       )}
       {...props}
@@ -70,8 +70,8 @@ export function TabsTrigger({
       className={cn(
         "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isActive
-          ? "bg-accent text-accent-foreground font-semibold shadow-sm"
-          : "text-muted-foreground hover:text-foreground",
+          ? "bg-zinc-800 text-white font-semibold border border-zinc-700 shadow-sm"
+          : "text-zinc-500 hover:text-zinc-300",
         className
       )}
       {...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the dashboard and admin tabs to match the app's dark tactical theme.

## Changes
- **TabsList**: Replaced generic `bg-muted` with `border-zinc-800` and `bg-zinc-900/50` to align with the PulseSidebar and other themed components
- **TabsTrigger (active)**: Uses `bg-zinc-800`, `text-white`, and `border-zinc-700` for clear visual distinction of the selected tab
- **TabsTrigger (inactive)**: Uses `text-zinc-500` with `hover:text-zinc-300` for consistent hierarchy

The tabs now use the same zinc palette as the sidebar, cards, and other UI elements for a cohesive dark tactical aesthetic.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://det165dev.slack.com/archives/C0ALXN9B5CN/p1773763052858729?thread_ts=1773763052.858729&cid=C0ALXN9B5CN)

<div><a href="https://cursor.com/agents/bc-16904424-9d56-528c-88ae-056c582f2aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16904424-9d56-528c-88ae-056c582f2aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

